### PR TITLE
feat(user): Allow password_change_frequency to be null.

### DIFF
--- a/src/contensis_management/models/user.py
+++ b/src/contensis_management/models/user.py
@@ -15,7 +15,7 @@ class Provider(camel_case.CamelModel):
 class Credentials(camel_case.CamelModel):
     """A Contensis user credentials model."""
 
-    passwordChangeFrequency: int
+    password_change_frequency: int | None = None
     provider: Provider
 
 
@@ -46,7 +46,7 @@ class User(camel_case.CamelModel):
     modified: datetime | None = None
     expiry: datetime | None = None
     password_changed: datetime | None = None
-    opt_out_of_notifications: bool
+    opt_out_of_notifications: bool | None = None
     failed_login_attempts: int | None = None
     failed_login_attempts_since_last_success: int | None = None
     successful_login_attempts: int | None = None

--- a/tests/models/user_test.py
+++ b/tests/models/user_test.py
@@ -1,0 +1,27 @@
+"""Confirm that the User model works as expected."""
+import copy
+
+from contensis_management.models import user
+
+example_user = {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "username": "admin",
+    "first_name": "Admin",
+    "last_name": "User",
+}
+
+def test_user():
+    """Confirm the password change frequency can be a null."""
+    # Arrange
+    test_user = copy.deepcopy(example_user)
+    test_user["credentials"] = {
+        "password_change_frequency": None,
+        "provider": {
+            "type": "contensis",
+            "name": "Contensis",
+        },
+    }
+    # Act
+    the_user = user.User(**test_user)
+    # Assert
+    assert the_user.credentials.password_change_frequency is None


### PR DESCRIPTION
Allow the passwordChangeFrequency to be null.  This can often occur for Active Directory authenticated users (discovered by @sihoran ).  And avoids the error below from 20 Jan 2024.

```
    |   File "/data/platform/.venv/lib/python3.13/site-packages/pydantic/main.py", line 214, in __init__
    |     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
    | pydantic_core._pydantic_core.ValidationError: 1 validation error for User
    | credentials.passwordChangeFrequency
    |   Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]
    |     For further information visit https://errors.pydantic.dev/2.10/v/int_type
```